### PR TITLE
mixin helper router methods

### DIFF
--- a/src/Providers/RoutingServiceProvider.php
+++ b/src/Providers/RoutingServiceProvider.php
@@ -42,9 +42,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('router', function ($app) {
-            return new Router($app['events'], $app);
-        });
+        $this->app['router']->mixin(new Router());
 
         parent::register();
     }

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1,7 +1,6 @@
 <?php namespace Arcanedev\Localization\Routing;
 
 use Closure;
-use Illuminate\Routing\Router as IlluminateRouter;
 
 /**
  * Class     Router
@@ -9,7 +8,7 @@ use Illuminate\Routing\Router as IlluminateRouter;
  * @package  Arcanedev\Localization\Routing
  * @author   ARCANEDEV <arcanedev.maroc@gmail.com>
  */
-class Router extends IlluminateRouter
+class Router
 {
     /* -----------------------------------------------------------------
      |  Getters & Setters
@@ -19,13 +18,15 @@ class Router extends IlluminateRouter
     /**
      * Get active middlewares.
      *
-     * @return array
+     * @return Closure|array
      */
     protected function getActiveMiddlewares()
     {
-        return array_keys(array_filter(
-            config('localization.route.middleware', [])
-        ));
+        return function() {
+            return array_keys(array_filter(
+                config('localization.route.middleware', [])
+            ));
+        };
     }
 
     /* -----------------------------------------------------------------
@@ -36,122 +37,139 @@ class Router extends IlluminateRouter
     /**
      * Create a route group with shared attributes.
      *
-     * @param  array     $attributes
-     * @param  \Closure  $callback
+     * @return Closure
+     * @internal param array $attributes
+     * @internal param Closure $callback
      */
-    public function localizedGroup(Closure $callback, $attributes = [])
+    public function localizedGroup()
     {
-        $attributes = array_merge($attributes, [
-            'prefix'     => localization()->setLocale(),
-            'middleware' => $this->getActiveMiddlewares(),
-        ]);
+        return function(Closure $callback, $attributes = []) {
+            $attributes = array_merge($attributes, [
+                'prefix' => localization()->setLocale(),
+                'middleware' => $this->getActiveMiddlewares(),
+            ]);
 
-        $this->group(array_filter($attributes), $callback);
+            $this->group(array_filter($attributes), $callback);
+        };
     }
 
     /**
      * Register a new translated GET route with the router.
      *
-     * @param  string                 $trans
-     * @param  \Closure|array|string  $action
+     * @return Closure|\Illuminate\Routing\Route
+     * @internal param string $trans
+     * @internal param array|Closure|string $action
      *
-     * @return \Illuminate\Routing\Route
      */
-    public function transGet($trans, $action)
+    public function transGet()
     {
-        return $this->get(
-            $this->transRoute($trans), $action
-        );
+        return function($trans, $action) {
+            return $this->get(
+                $this->transRoute($trans), $action
+            );
+        };
     }
 
     /**
      * Register a new translated POST route with the router.
      *
-     * @param  string                 $trans
-     * @param  \Closure|array|string  $action
+     * @return Closure|\Illuminate\Routing\Route
+     * @internal param string $trans
+     * @internal param array|Closure|string $action
      *
-     * @return \Illuminate\Routing\Route
      */
-    public function transPost($trans, $action)
+    public function transPost()
     {
-        return $this->post(
-            $this->transRoute($trans), $action
-        );
+        return function($trans, $action) {
+            return $this->post(
+                $this->transRoute($trans), $action
+            );
+        };
     }
 
     /**
      * Register a new translated PUT route with the router.
      *
-     * @param  string                 $trans
-     * @param  \Closure|array|string  $action
+     * @return Closure|\Illuminate\Routing\Route
+     * @internal param string $trans
+     * @internal param array|Closure|string $action
      *
-     * @return \Illuminate\Routing\Route
      */
-    public function transPut($trans, $action)
+    public function transPut()
     {
-        return $this->put(
-            $this->transRoute($trans), $action
-        );
+        return function($trans, $action) {
+            return $this->put(
+                $this->transRoute($trans), $action
+            );
+        };
     }
 
     /**
      * Register a new translated PATCH route with the router.
      *
-     * @param  string                 $trans
-     * @param  \Closure|array|string  $action
+     * @return Closure|\Illuminate\Routing\Route
+     * @internal param string $trans
+     * @internal param array|Closure|string $action
      *
-     * @return \Illuminate\Routing\Route
      */
-    public function transPatch($trans, $action)
+    public function transPatch()
     {
-        return $this->patch(
-            $this->transRoute($trans), $action
-        );
+        return function($trans, $action) {
+            return $this->patch(
+                $this->transRoute($trans), $action
+            );
+        };
     }
 
     /**
      * Register a new translated DELETE route with the router.
      *
-     * @param  string                 $trans
-     * @param  \Closure|array|string  $action
+     * @return Closure|\Illuminate\Routing\Route
+     * @internal param string $trans
+     * @internal param array|Closure|string $action
      *
-     * @return \Illuminate\Routing\Route
      */
-    public function transDelete($trans, $action)
+    public function transDelete()
     {
-        return $this->delete(
-            $this->transRoute($trans), $action
-        );
+        return function($trans, $action) {
+            return $this->delete(
+                $this->transRoute($trans), $action
+            );
+        };
     }
 
     /**
      * Register a new translated OPTIONS route with the router.
      *
-     * @param  string                 $trans
-     * @param  \Closure|array|string  $action
+     * @return Closure|\Illuminate\Routing\Route
+     * @internal param string $trans
+     * @internal param array|Closure|string $action
      *
-     * @return \Illuminate\Routing\Route
      */
-    public function transOptions($trans, $action)
+    public function transOptions()
     {
-        return $this->options(
-            $this->transRoute($trans), $action
-        );
+        return function($trans, $action) {
+            return $this->options(
+                $this->transRoute($trans), $action
+            );
+        };
     }
 
     /**
      * Register a new translated any route with the router.
      *
-     * @param  string                 $trans
-     * @param  \Closure|array|string  $action
+     * @return Closure|\Illuminate\Routing\Route
+     * @internal param string $trans
+     * @internal param array|Closure|string $action
      *
-     * @return \Illuminate\Routing\Route
      */
-    public function transAny($trans, $action)
+    public function transAny()
     {
-        return $this->any(
-            $this->transRoute($trans), $action
-        );
+        return function($trans, $action) {
+            return $this->any(
+                $this->transRoute($trans), $action
+            );
+        };
     }
 
     /* -----------------------------------------------------------------
@@ -162,12 +180,14 @@ class Router extends IlluminateRouter
     /**
      * Translate the route.
      *
-     * @param  string  $key
+     * @return Closure|string
+     * @internal param string $key
      *
-     * @return string
      */
-    private function transRoute($key)
+    protected function transRoute()
     {
-        return localization()->transRoute($key);
+        return function($key) {
+            return localization()->transRoute($key);
+        };
     }
 }

--- a/tests/Routing/RouterTest.php
+++ b/tests/Routing/RouterTest.php
@@ -1,6 +1,6 @@
 <?php namespace Arcanedev\Localization\Tests\Routing;
 
-use Arcanedev\Localization\Routing\Router;
+use Illuminate\Routing\Router;
 use Arcanedev\Localization\Tests\TestCase;
 
 /**

--- a/tests/Stubs/Http/RouteRegistrar.php
+++ b/tests/Stubs/Http/RouteRegistrar.php
@@ -1,6 +1,6 @@
 <?php namespace Arcanedev\Localization\Tests\Stubs\Http;
 
-use Arcanedev\Localization\Routing\Router;
+use Illuminate\Routing\Router;
 
 /**
  * Class     RouteRegistrar


### PR DESCRIPTION
in some case, there are routes registered by providers of others packages and these providers run before `RoutingServiceProvider` of this package,

so because this package create a new extend instance of `Arcanedev\Localization\Routing\Router` to add helpers method to  default `\Illuminate\Routing\Router` it causes
missing routes they registered by others packages of Laravel

this PR use `Macroable` trait of `Illuminate\Routing\Router` to add localization helper methods without destroying `Illuminate\Routing\Router` object