### PR TITLE
Update AR regional

### DIFF
--- a/config/localization.php
+++ b/config/localization.php
@@ -140,7 +140,7 @@ return [
             'script'   => 'Arab',
             'dir'      => 'rtl',
             'native'   => 'العربية',
-            'regional' => 'ar_AE',
+            'regional' => 'ar_AA',
         ],
         'as'          => [
             'name'     => 'Assamese',


### PR DESCRIPTION
It's better to use the standard code for Arabic regional **AA**.