### PR TITLE
Don't send locale cookie if next request returns a StreamedResponse

### DIFF
--- a/src/Middleware/LocaleCookieRedirect.php
+++ b/src/Middleware/LocaleCookieRedirect.php
@@ -31,7 +31,7 @@ class LocaleCookieRedirect extends Middleware
     public function handle(Request $request, Closure $next)
     {
         // If the request URL is ignored from localization.
-        if ($this->shouldIgnore($request)) return $next($request);
+        if ($this->shouldIgnore($request) || class_basename($next($request)) === 'StreamedResponse') return $next($request);
 
         $segment = $request->segment(1, null);
 


### PR DESCRIPTION
This will prevent the cookie from being sent if the next request returns a `Symfony\Component\HttpFoundation\StreamedResponse`.

Otherwise the following error would occur:
`Call to undefined method Symfony\Component\HttpFoundation\StreamedResponse::withCookie()`