### PR TITLE
Fix LocaleCookieRedirect middleware

### DIFF
--- a/src/Middleware/LocaleCookieRedirect.php
+++ b/src/Middleware/LocaleCookieRedirect.php
@@ -39,9 +39,9 @@ class LocaleCookieRedirect extends Middleware
 
         $locale  = $request->cookie('locale', null);
 
-        if ($locale !== null && ! $this->isDefaultLocaleHidden($locale)) {
+        if ($this->localization->isLocaleSupported($locale) && $locale !== null && ! $this->isDefaultLocaleHidden($locale)) {
             if ( ! is_null($redirect = $this->getLocalizedRedirect($locale)))
-                return $redirect->withCookie(cookie()->forever('locale', $segment));
+                return $redirect->withCookie(cookie()->forever('locale', $locale));
         }
 
         return $next($request);

--- a/src/Middleware/LocaleCookieRedirect.php
+++ b/src/Middleware/LocaleCookieRedirect.php
@@ -39,7 +39,7 @@ class LocaleCookieRedirect extends Middleware
 
         $locale  = $request->cookie('locale', null);
 
-        if ($this->localization->isLocaleSupported($locale) && ! $this->isDefaultLocaleHidden($locale)) {
+        if (! empty($locale) && ! $this->isDefaultLocaleHidden($locale)) {
             if ( ! is_null($redirect = $this->getLocalizedRedirect($locale)))
                 return $redirect->withCookie(cookie()->forever('locale', $locale));
         }

--- a/src/Middleware/LocaleCookieRedirect.php
+++ b/src/Middleware/LocaleCookieRedirect.php
@@ -39,7 +39,7 @@ class LocaleCookieRedirect extends Middleware
 
         $locale  = $request->cookie('locale', null);
 
-        if ($this->localization->isLocaleSupported($locale) && $locale !== null && ! $this->isDefaultLocaleHidden($locale)) {
+        if ($this->localization->isLocaleSupported($locale) && ! $this->isDefaultLocaleHidden($locale)) {
             if ( ! is_null($redirect = $this->getLocalizedRedirect($locale)))
                 return $redirect->withCookie(cookie()->forever('locale', $locale));
         }

--- a/tests/Middleware/LocaleCookieRedirectTest.php
+++ b/tests/Middleware/LocaleCookieRedirectTest.php
@@ -49,17 +49,4 @@ class LocaleCookieRedirectTest extends TestCase
         static::assertSame(302, $response->getStatusCode());
         static::assertSame($this->testUrlOne . 'en', $response->getTargetUrl());
     }
-
-    /** @test */
-    public function it_can_pass_redirect_with_unsupported_locale_in_cookie(): void
-    {
-        $this->refreshApplication(false, true, true);
-
-        $supported = ['en', 'es'];
-        localization()->setSupportedLocales($supported);
-        static::assertSame($supported, localization()->getSupportedLocalesKeys());
-
-        $response = $this->call('GET', $this->testUrlOne, [], ['locale' => 'fr']);
-        static::assertSame(302, $response->getStatusCode());
-    }
 }

--- a/tests/Middleware/LocaleCookieRedirectTest.php
+++ b/tests/Middleware/LocaleCookieRedirectTest.php
@@ -49,4 +49,17 @@ class LocaleCookieRedirectTest extends TestCase
         static::assertSame(302, $response->getStatusCode());
         static::assertSame($this->testUrlOne . 'en', $response->getTargetUrl());
     }
+
+    /** @test */
+    public function it_can_pass_redirect_with_unsupported_locale_in_cookie(): void
+    {
+        $this->refreshApplication(false, true, true);
+
+        $supported = ['en', 'es'];
+        localization()->setSupportedLocales($supported);
+        static::assertSame($supported, localization()->getSupportedLocalesKeys());
+
+        $response = $this->call('GET', $this->testUrlOne, [], ['locale' => 'fr']);
+        static::assertSame(302, $response->getStatusCode());
+    }
 }


### PR DESCRIPTION
I've been using this package for quite a few years and only recently been having some weird issues:

When the cookie locale contains an empty string, the following exception occurs:
```
Arcanedev\Localization\Exceptions\UnsupportedLocaleException
Locale '' is not in the list of supported locales. 
```
I'm still unsure why the locale from the cookie would be empty, but I believe we can fix this by checking if the locale from the cookie is actually supported, just like the segment is checked (line 42).

This will also prevent an exception if a user has a locale set in their cookie which is no longer supported.
I've run into this situation recently and the only fix was to force remove the locale cookie on each request.

Sometimes the first segment of the URL is stored as the locale in the cookie, throwing a similar exception:
```
Arcanedev\Localization\Exceptions\UnsupportedLocaleException
Locale 'products' is not in the list of supported locales. 
```
I might be off, but this probably happens because the segment is stored instead of the locale from the cookie (line 44).